### PR TITLE
Support for deriving datastore conversion traits on enums + Renaming fields

### DIFF
--- a/google-cloud-derive/Cargo.toml
+++ b/google-cloud-derive/Cargo.toml
@@ -13,9 +13,10 @@ name = "tests"
 path = "tests/tests.rs"
 
 [dependencies]
-syn = { version = "1.0.13", features = ["full", "extra-traits"] }
-quote = "1.0.2"
+syn = { version = "1.0.17", features = ["full", "extra-traits"] }
+quote = "1.0.3"
+darling = "0.10.2"
 
 [dev-dependencies]
-trybuild = "1.0.19"
+trybuild = "1.0.25"
 google-cloud = { path = "../google-cloud", features = ["derive"] }

--- a/google-cloud-derive/src/casing.rs
+++ b/google-cloud-derive/src/casing.rs
@@ -1,0 +1,66 @@
+use crate::RenameAll;
+
+pub(crate) fn transform_variant_casing(variant: syn::Ident, rename_all: RenameAll) -> String {
+    match rename_all {
+        RenameAll::LowerCase => variant.to_string().to_ascii_lowercase(),
+        RenameAll::UpperCase => variant.to_string().to_ascii_uppercase(),
+        RenameAll::CamelCase => {
+            let variant = variant.to_string();
+            variant[..1].to_ascii_lowercase() + &variant[1..]
+        }
+        RenameAll::PascalCase => variant.to_string(),
+        RenameAll::SnakeCase => {
+            let variant = variant.to_string();
+            let mut snake = String::new();
+            for (i, ch) in variant.char_indices() {
+                if i > 0 && ch.is_uppercase() {
+                    snake.push('_');
+                }
+                snake.push(ch.to_ascii_lowercase());
+            }
+            snake
+        }
+        RenameAll::ScreamingSnakeCase => {
+            transform_variant_casing(variant, RenameAll::SnakeCase).to_ascii_uppercase()
+        }
+        RenameAll::KebabCase => {
+            transform_variant_casing(variant, RenameAll::SnakeCase).replace('_', "-")
+        }
+        RenameAll::ScreamingKebabCase => {
+            transform_variant_casing(variant, RenameAll::ScreamingSnakeCase).replace('_', "-")
+        }
+    }
+}
+
+pub(crate) fn transform_field_casing(field: syn::Ident, rename_all: RenameAll) -> String {
+    match rename_all {
+        RenameAll::LowerCase => field.to_string(),
+        RenameAll::UpperCase => field.to_string().to_ascii_uppercase(),
+        RenameAll::CamelCase => {
+            let pascal = transform_field_casing(field, RenameAll::PascalCase);
+            pascal[..1].to_ascii_lowercase() + &pascal[1..]
+        }
+        RenameAll::PascalCase => {
+            let field = field.to_string();
+            let mut pascal = String::new();
+            let mut capitalize = true;
+            for ch in field.chars() {
+                if ch == '_' {
+                    capitalize = true;
+                } else if capitalize {
+                    pascal.push(ch.to_ascii_uppercase());
+                    capitalize = false;
+                } else {
+                    pascal.push(ch);
+                }
+            }
+            pascal
+        }
+        RenameAll::SnakeCase => field.to_string(),
+        RenameAll::ScreamingSnakeCase => field.to_string().to_ascii_uppercase(),
+        RenameAll::KebabCase => field.to_string().replace('_', "-"),
+        RenameAll::ScreamingKebabCase => {
+            transform_field_casing(field, RenameAll::ScreamingSnakeCase).replace('_', "-")
+        }
+    }
+}

--- a/google-cloud-derive/src/lib.rs
+++ b/google-cloud-derive/src/lib.rs
@@ -1,36 +1,96 @@
 extern crate proc_macro;
 
 use proc_macro::TokenStream;
+
+use darling::{FromDeriveInput, FromField, FromMeta, FromVariant};
 use quote::quote;
 use syn::parse_macro_input;
-use syn::{Fields, FieldsNamed, Ident, ItemStruct, LitInt, LitStr};
 
-#[proc_macro_derive(IntoValue)]
-pub fn derive_into_value(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as ItemStruct);
+mod casing;
 
-    let name = &input.ident;
-    let (keys, fields) = if let Fields::Named(FieldsNamed { ref named, .. }) = input.fields {
-        let fields: Vec<&Ident> = named
-            .iter()
-            .map(|field| field.ident.as_ref().unwrap())
-            .collect();
-        let keys: Vec<LitStr> = fields
-            .iter()
-            .map(|ident| LitStr::new(ident.to_string().as_str(), ident.span()))
-            .collect();
-        (keys, fields)
-    } else {
-        todo!()
-    };
+use crate::casing::{transform_field_casing, transform_variant_casing};
 
-    let capacity = LitInt::new(keys.len().to_string().as_str(), name.span());
+#[derive(Debug, Clone, Copy, PartialEq, Eq, FromMeta)]
+pub(crate) enum RenameAll {
+    #[darling(rename = "lowercase")]
+    LowerCase,
+    #[darling(rename = "UPPERCASE")]
+    UpperCase,
+    #[darling(rename = "PascalCase")]
+    PascalCase,
+    #[darling(rename = "camelCase")]
+    CamelCase,
+    #[darling(rename = "snake_case")]
+    SnakeCase,
+    #[darling(rename = "SCREAMING_SNAKE_CASE")]
+    ScreamingSnakeCase,
+    #[darling(rename = "kebab-case")]
+    KebabCase,
+    #[darling(rename = "SCREAMING-KEBAB-CASE")]
+    ScreamingKebabCase,
+}
+
+impl Default for RenameAll {
+    fn default() -> RenameAll {
+        RenameAll::CamelCase
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, FromDeriveInput)]
+#[darling(attributes(datastore), supports(struct_named, enum_unit))]
+struct Container {
+    pub ident: syn::Ident,
+    // pub vis: syn::Visibility,
+    // pub generics: syn::Generics,
+    pub data: darling::ast::Data<VariantContainer, FieldContainer>,
+    // pub attrs: Vec<syn::Attribute>,
+    #[darling(default)]
+    pub rename_all: RenameAll,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, FromVariant)]
+#[darling(attributes(datastore))]
+struct VariantContainer {
+    pub ident: syn::Ident,
+    #[darling(default)]
+    pub rename: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, FromField)]
+#[darling(attributes(datastore))]
+struct FieldContainer {
+    pub ident: Option<syn::Ident>,
+    #[darling(default)]
+    pub rename: Option<String>,
+}
+
+fn derive_into_value_struct(
+    ident: syn::Ident,
+    fields: Vec<FieldContainer>,
+    rename_all: RenameAll,
+) -> TokenStream {
+    let idents: Vec<syn::Ident> = fields
+        .iter()
+        .map(|field| field.ident.clone().unwrap())
+        .collect();
+    let names: Vec<syn::LitStr> = fields
+        .into_iter()
+        .map(|field| {
+            let renamed = field.rename;
+            let field = field.ident.unwrap();
+            let span = field.span();
+            let name = renamed.unwrap_or_else(|| transform_field_casing(field, rename_all));
+            syn::LitStr::new(name.as_str(), span)
+        })
+        .collect();
+
+    let capacity = names.len();
 
     let tokens = quote! {
-        impl ::google_cloud::datastore::IntoValue for #name {
+        impl ::google_cloud::datastore::IntoValue for #ident {
             fn into_value(self) -> ::google_cloud::datastore::Value {
                 let mut props = ::std::collections::HashMap::with_capacity(#capacity);
-                #(props.insert(String::from(#keys), self.#fields.into_value());)*
+                #(props.insert(::std::string::String::from(#names), self.#idents.into_value());)*
                 ::google_cloud::datastore::Value::EntityValue(props)
             }
         }
@@ -39,50 +99,161 @@ pub fn derive_into_value(input: TokenStream) -> TokenStream {
     tokens.into()
 }
 
-#[proc_macro_derive(FromValue)]
-pub fn derive_from_value(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as ItemStruct);
-
-    let name = &input.ident;
-    let (keys, fields) = if let Fields::Named(FieldsNamed { ref named, .. }) = input.fields {
-        let fields: Vec<&Ident> = named
-            .iter()
-            .map(|field| field.ident.as_ref().unwrap())
-            .collect();
-        let keys: Vec<LitStr> = fields
-            .iter()
-            .map(|ident| LitStr::new(ident.to_string().as_str(), ident.span()))
-            .collect();
-        (keys, fields)
-    } else {
-        todo!()
-    };
+fn derive_into_value_enum(
+    ident: syn::Ident,
+    variants: Vec<VariantContainer>,
+    rename_all: RenameAll,
+) -> TokenStream {
+    let idents: Vec<syn::Ident> = variants
+        .iter()
+        .map(|variant| variant.ident.clone())
+        .collect();
+    let names: Vec<syn::LitStr> = variants
+        .into_iter()
+        .map(|variant| {
+            let renamed = variant.rename;
+            let variant = variant.ident;
+            let span = variant.span();
+            let name = renamed.unwrap_or_else(|| transform_variant_casing(variant, rename_all));
+            syn::LitStr::new(name.as_str(), span)
+        })
+        .collect();
 
     let tokens = quote! {
-        impl ::google_cloud::datastore::FromValue for #name {
-            fn from_value(value: ::google_cloud::datastore::Value) -> std::result::Result<#name, ::google_cloud::error::ConvertError> {
-                let mut props = match value {
-                    ::google_cloud::datastore::Value::EntityValue(props) => props,
-                    _ => return Err(::google_cloud::error::ConvertError::UnexpectedPropertyType {
-                        expected: String::from("entity"),
-                        got: String::from(value.type_name()),
-                    }),
-                };
-                let value = #name {
-                    #(#fields: {
-                        let prop = props
-                            .remove(#keys)
-                            .ok_or_else(|| {
-                                ::google_cloud::error::ConvertError::MissingProperty(String::from(#keys))
-                            })?;
-                        let value = ::google_cloud::datastore::FromValue::from_value(prop)?;
-                        value
-                    },)*
-                };
-                Ok(value)
+        impl ::google_cloud::datastore::IntoValue for #ident {
+            fn into_value(self) -> ::google_cloud::datastore::Value {
+                match self {
+                    #(#ident::#idents => ::google_cloud::datastore::Value::StringValue(#names.to_string()),)*
+                }
             }
         }
     };
 
     tokens.into()
+}
+
+#[proc_macro_derive(IntoValue, attributes(datastore))]
+pub fn derive_into_value(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as syn::DeriveInput);
+    let container = Container::from_derive_input(&input).unwrap();
+
+    let ident = container.ident;
+    let rename_all = container.rename_all;
+
+    match container.data {
+        darling::ast::Data::Enum(variants) => derive_into_value_enum(ident, variants, rename_all),
+        darling::ast::Data::Struct(darling::ast::Fields { fields, .. }) => {
+            derive_into_value_struct(ident, fields, rename_all)
+        }
+    }
+}
+
+fn derive_from_value_struct(
+    ident: syn::Ident,
+    fields: Vec<FieldContainer>,
+    rename_all: RenameAll,
+) -> TokenStream {
+    let idents: Vec<syn::Ident> = fields
+        .iter()
+        .map(|field| field.ident.clone().unwrap())
+        .collect();
+    let names: Vec<syn::LitStr> = fields
+        .into_iter()
+        .map(|field| {
+            let renamed = field.rename;
+            let field = field.ident.unwrap();
+            let span = field.span();
+            let name = renamed.unwrap_or_else(|| transform_field_casing(field, rename_all));
+            syn::LitStr::new(name.as_str(), span)
+        })
+        .collect();
+
+    let tokens = quote! {
+        impl ::google_cloud::datastore::FromValue for #ident {
+            fn from_value(value: ::google_cloud::datastore::Value) -> ::std::result::Result<#ident, ::google_cloud::error::ConvertError> {
+                let mut props = match value {
+                    ::google_cloud::datastore::Value::EntityValue(props) => props,
+                    _ => return ::std::result::Result::Err(
+                        ::google_cloud::error::ConvertError::UnexpectedPropertyType {
+                            expected: ::std::string::String::from("entity"),
+                            got: ::std::string::String::from(value.type_name()),
+                        }
+                    ),
+                };
+                let value = #ident {
+                    #(#idents: {
+                        let prop = props
+                            .remove(#names)
+                            .ok_or_else(|| {
+                                ::google_cloud::error::ConvertError::MissingProperty(::std::string::String::from(#names))
+                            })?;
+                        let value = ::google_cloud::datastore::FromValue::from_value(prop)?;
+                        value
+                    },)*
+                };
+                ::std::result::Result::Ok(value)
+            }
+        }
+    };
+
+    tokens.into()
+}
+
+fn derive_from_value_enum(
+    ident: syn::Ident,
+    variants: Vec<VariantContainer>,
+    rename_all: RenameAll,
+) -> TokenStream {
+    let idents: Vec<syn::Ident> = variants
+        .iter()
+        .map(|variant| variant.ident.clone())
+        .collect();
+    let names: Vec<syn::LitStr> = variants
+        .into_iter()
+        .map(|variant| {
+            let renamed = variant.rename;
+            let variant = variant.ident;
+            let span = variant.span();
+            let name = renamed.unwrap_or_else(|| transform_variant_casing(variant, rename_all));
+            syn::LitStr::new(name.as_str(), span)
+        })
+        .collect();
+
+    let tokens = quote! {
+        impl ::google_cloud::datastore::FromValue for #ident {
+            fn from_value(value: ::google_cloud::datastore::Value) -> ::std::result::Result<#ident, ::google_cloud::error::ConvertError> {
+                let value = match value {
+                    ::google_cloud::datastore::Value::StringValue(value) => value,
+                    _ => return ::std::result::Result::Err(
+                        ::google_cloud::error::ConvertError::UnexpectedPropertyType {
+                            expected: ::std::string::String::from("entity"),
+                            got: ::std::string::String::from(value.type_name()),
+                        }
+                    ),
+                };
+                match value.as_str() {
+                    #(#names => ::std::result::Result::Ok(#ident::#idents),)*
+                    _ => todo!("[datastore-derive] unknown enum variant encountered"),
+                }
+            }
+        }
+    };
+
+    tokens.into()
+}
+
+#[proc_macro_derive(FromValue, attributes(datastore))]
+pub fn derive_from_value(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as syn::DeriveInput);
+    let container = Container::from_derive_input(&input).unwrap();
+
+    let ident = container.ident;
+    let rename_all = container.rename_all;
+
+    match container.data {
+        darling::ast::Data::Enum(variants) => derive_from_value_enum(ident, variants, rename_all),
+        darling::ast::Data::Struct(darling::ast::Fields { fields, .. }) => {
+            derive_from_value_struct(ident, fields, rename_all)
+        }
+    }
 }

--- a/google-cloud-derive/tests/01-simple.rs
+++ b/google-cloud-derive/tests/01-simple.rs
@@ -1,10 +1,24 @@
-use google_cloud_derive::{FromValue, IntoValue};
+use google_cloud::datastore::{FromValue, IntoValue};
+use google_cloud::error::ConvertError;
 
-#[derive(FromValue, IntoValue)]
+#[derive(Debug, FromValue, IntoValue)]
 pub struct Foo {
     bar: String,
     baz: i64,
     qux: bool,
 }
 
-fn main() {}
+fn main() {
+    let foo = Foo {
+        bar: String::from("test"),
+        baz: 63,
+        qux: true,
+    };
+    println!("original: {:?}", foo);
+
+    let converted = foo.into_value();
+    println!("converted: {:?}", converted);
+
+    let recovered: Result<Foo, ConvertError> = Foo::from_value(converted);
+    println!("recovered: {:?}", recovered);
+}

--- a/google-cloud-derive/tests/03-enums.rs
+++ b/google-cloud-derive/tests/03-enums.rs
@@ -2,23 +2,17 @@ use google_cloud::datastore::{FromValue, IntoValue};
 use google_cloud::error::ConvertError;
 
 #[derive(Debug, FromValue, IntoValue)]
-pub struct Foo {
-    bar: Bar,
-    qux: bool,
-}
-
-#[derive(Debug, FromValue, IntoValue)]
-pub struct Bar {
-    baz: String,
+#[datastore(rename_all = "SCREAMING-KEBAB-CASE")]
+pub enum Foo {
+    Bar,
+    Baz,
+    TrickyOne,
+    AndAnotherOne,
+    AreWeThereYet,
 }
 
 fn main() {
-    let foo = Foo {
-        bar: Bar {
-            baz: String::from("test"),
-        },
-        qux: true,
-    };
+    let foo = Foo::AreWeThereYet;
     println!("original: {:?}", foo);
 
     let converted = foo.into_value();

--- a/google-cloud-derive/tests/tests.rs
+++ b/google-cloud-derive/tests/tests.rs
@@ -5,4 +5,5 @@ fn tests() {
     let tests = TestCases::new();
     tests.pass("tests/01-simple.rs");
     tests.pass("tests/02-nested.rs");
+    tests.pass("tests/03-enums.rs");
 }

--- a/google-cloud/Cargo.toml
+++ b/google-cloud/Cargo.toml
@@ -12,24 +12,24 @@ keywords = ["grpc", "futures", "async", "protobuf", "google", "cloud"]
 google-cloud-derive = { version = "=0.1.0", path = "../google-cloud-derive", optional = true }
 
 tonic = { version = "0.2.0", features = ["tls", "prost"] }
-tokio = { version = "0.2.9", features = ["macros", "fs"] }
+tokio = { version = "0.2.18", features = ["macros", "fs"] }
 isahc = { version = "0.9.1", features = ["json"] }
-reqwest = { version = "0.10.1", features = ["blocking", "json", "rustls-tls"] }
-futures = "0.3.1"
+reqwest = { version = "0.10.4", features = ["blocking", "json", "rustls-tls"] }
+futures = "0.3.4"
 
 prost = "0.6.1"
 prost-types = "0.6.1"
 
-http = "0.2.0"
-chrono = "0.4.10"
+http = "0.2.1"
+chrono = "0.4.11"
 
-serde = { version = "1.0.104", features = ["derive"] }
-json = { package = "serde_json", version = "1.0.44" }
+serde = { version = "1.0.106", features = ["derive"] }
+json = { package = "serde_json", version = "1.0.51" }
 jwt = { package = "frank_jwt", version = "3.1.2" }
 
-thiserror = "1.0.9"
+thiserror = "1.0.15"
 
-bytes = { version = "0.5.3", optional = true }
+bytes = { version = "0.5.4", optional = true }
 
 [build-dependencies]
 tonic-build = "0.2.0"

--- a/google-cloud/src/datastore/api/google.datastore.v1.rs
+++ b/google-cloud/src/datastore/api/google.datastore.v1.rs
@@ -866,7 +866,7 @@ pub mod transaction_options {
         ReadOnly(ReadOnly),
     }
 }
-#[doc = r" Generated server implementations."]
+#[doc = r" Generated client implementations."]
 pub mod datastore_client {
     #![allow(unused_variables, dead_code, missing_docs)]
     use tonic::codegen::*;
@@ -1028,6 +1028,11 @@ pub mod datastore_client {
             Self {
                 inner: self.inner.clone(),
             }
+        }
+    }
+    impl<T> std::fmt::Debug for DatastoreClient<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "DatastoreClient {{ ... }}")
         }
     }
 }

--- a/google-cloud/src/pubsub/api/google.pubsub.v1.rs
+++ b/google-cloud/src/pubsub/api/google.pubsub.v1.rs
@@ -784,7 +784,7 @@ pub mod seek_request {
 /// Response for the `Seek` method (this response is empty).
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SeekResponse {}
-#[doc = r" Generated server implementations."]
+#[doc = r" Generated client implementations."]
 pub mod publisher_client {
     #![allow(unused_variables, dead_code, missing_docs)]
     use tonic::codegen::*;
@@ -968,8 +968,13 @@ pub mod publisher_client {
             }
         }
     }
+    impl<T> std::fmt::Debug for PublisherClient<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "PublisherClient {{ ... }}")
+        }
+    }
 }
-#[doc = r" Generated server implementations."]
+#[doc = r" Generated client implementations."]
 pub mod subscriber_client {
     #![allow(unused_variables, dead_code, missing_docs)]
     use tonic::codegen::*;
@@ -1364,6 +1369,11 @@ pub mod subscriber_client {
             Self {
                 inner: self.inner.clone(),
             }
+        }
+    }
+    impl<T> std::fmt::Debug for SubscriberClient<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "SubscriberClient {{ ... }}")
         }
     }
 }

--- a/google-cloud/src/vision/api/google.cloud.vision.v1.rs
+++ b/google-cloud/src/vision/api/google.cloud.vision.v1.rs
@@ -644,7 +644,7 @@ pub mod purge_products_request {
         DeleteOrphanProducts(bool),
     }
 }
-#[doc = r" Generated server implementations."]
+#[doc = r" Generated client implementations."]
 pub mod product_search_client {
     #![allow(unused_variables, dead_code, missing_docs)]
     use tonic::codegen::*;
@@ -1164,6 +1164,11 @@ pub mod product_search_client {
             Self {
                 inner: self.inner.clone(),
             }
+        }
+    }
+    impl<T> std::fmt::Debug for ProductSearchClient<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "ProductSearchClient {{ ... }}")
         }
     }
 }
@@ -2490,7 +2495,7 @@ pub enum Likelihood {
     /// It is very likely.
     VeryLikely = 5,
 }
-#[doc = r" Generated server implementations."]
+#[doc = r" Generated client implementations."]
 pub mod image_annotator_client {
     #![allow(unused_variables, dead_code, missing_docs)]
     use tonic::codegen::*;
@@ -2625,6 +2630,11 @@ pub mod image_annotator_client {
             Self {
                 inner: self.inner.clone(),
             }
+        }
+    }
+    impl<T> std::fmt::Debug for ImageAnnotatorClient<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "ImageAnnotatorClient {{ ... }}")
         }
     }
 }

--- a/google-cloud/src/vision/api/google.longrunning.rs
+++ b/google-cloud/src/vision/api/google.longrunning.rs
@@ -137,7 +137,7 @@ pub struct OperationInfo {
     #[prost(string, tag = "2")]
     pub metadata_type: std::string::String,
 }
-#[doc = r" Generated server implementations."]
+#[doc = r" Generated client implementations."]
 pub mod operations_client {
     #![allow(unused_variables, dead_code, missing_docs)]
     use tonic::codegen::*;
@@ -300,6 +300,11 @@ pub mod operations_client {
             Self {
                 inner: self.inner.clone(),
             }
+        }
+    }
+    impl<T> std::fmt::Debug for OperationsClient<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "OperationsClient {{ ... }}")
         }
     }
 }


### PR DESCRIPTION
This PR adds support for deriving `google_cloud::datastore::{FromValue, IntoValue}` for enums which only contains unit variants (and includes an integration test for this feature).  
The derive will currently reject variants that holds any data, adding support for these cases will be addressed separately.  

This PR also adds support for renaming fields:
- using `#[datastore(rename_all = "<casing-name>")]` on the whole struct/enum.
- using `#[datastore(rename = "<field-name>")]` on a single field.

`rename_all = "<casing-name>"` allows to change the casing for all fields or variants, its values can be any of these (just like how the `serde` crate does it):
- `"lowercase"`
- `"UPPERCASE"`
- `"PascalCase"`
- `"camelCase"`
- `"snake_case"`
- `"kebab-case"`
- `"SCREAMING_SNAKE_CASE"`
- `"SCREAMING-KEBAB-CASE"`

`rename = "<field-name>"`, however, allows to choose an arbitrary name, its value is directly taken as the name of the field in its datastore form.