### PR TITLE
Move to `actions/checkout@v2` in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
           # - windows-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: true
 
@@ -51,7 +51,7 @@ jobs:
     name: Checking fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: true
 


### PR DESCRIPTION
This PR upgrades the CI workflow to use the newer `actions/checkout@v2`.  
It improves performance (by only fetching a single commit) and fixes some bugs from the old version.